### PR TITLE
Point directly to Xcode project

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     description: 'The path in which the Xcodeproj can be found.'
     required: false
     default: '.'
+  project:
+    description: 'The Xcodeproj that holds the SPM data'
+    required: true
   forceResolution:
     description: 'Always regenerate the Package.resolved, irrespective of conflicts.'
     required: false
@@ -28,5 +31,5 @@ runs:
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
     - id: script
-      run: entrypoint.sh -a "${{ inputs.directory }}" -b "${{ inputs.forceResolution }}" -c "${{ inputs.failWhenOutdated }}"
+      run: entrypoint.sh -a "${{ inputs.directory }}" -b "$ {{ inputs.project }}" -c "${{ inputs.forceResolution }}" -d "${{ inputs.failWhenOutdated }}" 
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ runs:
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
     - id: script
-      run: entrypoint.sh -a "${{ inputs.directory }}" -b "${{ inputs.project }}" -c "${{ inputs.forceResolution }}" -d "${{ inputs.failWhenOutdated }}"
+      run: entrypoint.sh -a "${{ inputs.directory }}" -b "${{ inputs.project }}" -c "${{ inputs.failWhenOutdated }}" -d "${{ inputs.forceResolution }}"
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ runs:
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
     - id: script
-      run: entrypoint.sh -a "${{ inputs.directory }}" -b "$ {{ inputs.project }}" -c "${{ inputs.forceResolution }}" -d "${{ inputs.failWhenOutdated }}" 
+      run: entrypoint.sh -a "${{ inputs.directory }}" -b "${{ inputs.project }}" -c "${{ inputs.forceResolution }}" -d "${{ inputs.failWhenOutdated }}"
       shell: bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Load Options
-while getopts "a:b:c:" o; do
+while getopts "a:b:c:d:" o; do
    case "${o}" in
        a)
          export directory=${OPTARG}
@@ -13,6 +13,9 @@ while getopts "a:b:c:" o; do
 	   c)
          export failWhenOutdated=${OPTARG}
        ;;
+	   d)
+         export project=${OPTARG}
+       ;;
   esac
 done
 
@@ -22,8 +25,8 @@ if [ "$directory" != "." ]; then
 	cd $directory
 fi
 
-# Identify `Package.resolved` location
-RESOLVED_PATH=$(find . -type f -name "Package.resolved" | grep -v "*/*.xcodeproj/*")
+# Looks directly in project file for SPM `Package.resolved`
+RESOLVED_PATH="$project.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 CHECKSUM=$(shasum "$RESOLVED_PATH")
 
 echo "Identified Package.resolved at '$RESOLVED_PATH'."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,13 +8,13 @@ while getopts "a:b:c:d:" o; do
          export directory=${OPTARG}
        ;;
        b)
-         export forceResolution=${OPTARG}
+         export project=${OPTARG}
        ;;
 	   c)
          export failWhenOutdated=${OPTARG}
        ;;
 	   d)
-         export project=${OPTARG}
+         export forceResolution=${OPTARG}
        ;;
   esac
 done


### PR DESCRIPTION
## What does this change?

The Guardian iOS project contains a local script package with its own `Package.resolved` file, in addition to the SPM packages for the entire project. This caused the original action to fail. 
I decided to add a parameter to allow the user of the action to point directly to the project file that contains the SPM `Package.resolved` file for the project.
There may be a nicer way of doing this by updating the `find` / `grep` line, but I am no pro at writing scripts so this is what I came up with. According to Apple, the resolved file should always live in [this](https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app ) location, so this change should be sufficient.
