### PR TITLE
Include only resolved files in xcodeproj

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -43,7 +43,7 @@ fi
 if [ ! -z "$workspaceName" ]; then
   RESOLVED_PATH=$(find $workspaceName -type f -name "Package.resolved" | grep -v "*/*.xcworkspace/*")
 else
-  RESOLVED_PATH=$(find . -type f -name "Package.resolved" | grep -v "*/*.xcodeproj/*")
+  RESOLVED_PATH=$(find . -type f -name "Package.resolved" -path "*/*.xcodeproj/*")
 fi
 
 CHECKSUM=$(shasum "$RESOLVED_PATH")


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We have recently been seeing issues where this Github action will fail as it will pick up multiple Package.resolved files in the given directory (if they are present). I'm assuming that this original line in the script was intended to only pick up Package.resolved files in xcodeproj directories - but it has been failing at doing so.

This PR addresses this so that it only picks up the primary Package.resolved file which lives in the Xcode project.

## How to test

I have tested this locally by running the script directly and can now see the expected behaviour.
