### PR TITLE
Add Project parameter for DerivedData deletion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ inputs:
   scheme:
     description: 'If specifying a workspace file, you must also provide a scheme as defined within your Xcode workspace.'
     required: false
+  project:
+    description: 'Provide the name of your Xcode project file'
+    required: false
 outputs:
   dependenciesChanged:
     description: 'A bool (true or false) indicating whether changes were made to the dependencies.'
@@ -37,5 +40,5 @@ runs:
     - run: echo "${{ github.action_path }}" >> $GITHUB_PATH
       shell: bash
     - id: script
-      run: entrypoint.sh -a "${{ inputs.directory }}" -b "${{ inputs.forceResolution }}" -c "${{ inputs.failWhenOutdated }}" -d "${{ inputs.xcodePath }}" -e "${{ inputs.workspace }}" -f "${{ inputs.scheme }}"
+      run: entrypoint.sh -a "${{ inputs.directory }}" -b "${{ inputs.forceResolution }}" -c "${{ inputs.failWhenOutdated }}" -d "${{ inputs.xcodePath }}" -e "${{ inputs.workspace }}" -f "${{ inputs.scheme }}" -g "${{ inputs.project }}"
       shell: bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Load Options
-while getopts "a:b:c:d:e:f:" o; do
+while getopts "a:b:c:d:e:f:g:" o; do
   case "${o}" in
   a)
     export directory=${OPTARG}
@@ -23,6 +23,9 @@ while getopts "a:b:c:d:e:f:" o; do
     ;;
   f)
     export scheme=${OPTARG}
+    ;;
+  g)
+    export projectName=${OPTARG}
     ;;
   esac
 done
@@ -57,9 +60,27 @@ else
   xcodebuildInputs=""
 fi
 
-# Cleanup Caches
-DERIVED_DATA=$(xcodebuild ${xcodebuildInputs} -showBuildSettings -disableAutomaticPackageResolution -skipPackageUpdates | grep -m 1 BUILD_DIR | grep -oE "\/.*" | sed 's|/Build/Products||')
-rm -rf "$DERIVED_DATA"
+# Default DerivedData path
+DERIVED_DATA_DIR=~/Library/Developer/Xcode/DerivedData
+
+if [ -z "$projectName" ]; then
+    echo "🔍 Scanning for recent derived data folders..."
+    echo "Tip: Pass your project/workspace name to narrow results."
+    
+    # List most recently modified folders
+    ls -lt "$DERIVED_DATA_DIR" | head -10
+else
+    echo "🔍 Looking for DerivedData folder matching: $projectName"
+    
+    MATCH=$(find "$DERIVED_DATA_DIR" -maxdepth 1 -type d -name "${projectName}-*" | head -n 1)
+    
+    if [ -n "$MATCH" ]; then
+        echo "✅ Found DerivedData folder:"
+        echo "$MATCH"
+    else
+        echo "❌ No DerivedData folder found matching: $projectName"
+    fi
+fi
 
 # If `forceResolution`, then delete the `Package.resolved`
 if [ "$forceResolution" = true ] || [ "$forceResolution" = 'true' ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -90,7 +90,7 @@ fi
 
 # Should be mostly redundant as we use the disable cache flag.
 SPM_CACHE="~/Library/Caches/org.swift.swiftpm/"
-rm -rf "$CACHE_PATH"
+rm -rf "$SPM_CACHE"
 
 # Resolve Dependencies
 echo "::group::xcodebuild resolve dependencies"


### PR DESCRIPTION
We continue to have issues with this Github Action not successfully updating our SPM dependencies. The action would run fine but no changes would be found. After some experimentation, I found that the script was not deleting the correct Derived Data folder. Having done this, I was able to run the script locally against our project and find that the packages were fetched from remote and updated successfully.

I also found a small mistake in the cache deletion, although I don't think this is doing anything useful anyway as we use the disable cache flag.